### PR TITLE
Use scratchpads instead of sticky windows in yabai

### DIFF
--- a/modules/darwin/configurations/skhd.nix
+++ b/modules/darwin/configurations/skhd.nix
@@ -49,7 +49,15 @@
             [
               hyper
               "s"
-              "${yabai} -m window --toggle sticky"
+              (
+                let
+                  scratchpad_cmd = "${yabai} -m window --scratchpad";
+                in
+                ''
+                  ${scratchpad_cmd} || \
+                  ${scratchpad_cmd} $(${yabai} -m query --windows --window | ${jq} -r '"sticky\(.id)"')
+                ''
+              )
             ]
             [
               hyper


### PR DESCRIPTION
This way windows don't get carried to other spaces