### PR TITLE
Update tmux config to match newer software

### DIFF
--- a/modules/home/configurations/tmux.nix
+++ b/modules/home/configurations/tmux.nix
@@ -10,19 +10,16 @@
     baseIndex = 1;
     disableConfirmationPrompt = true;
     keyMode = "vi";
+    shortcut = "a";
     terminal = "tmux-256color";
     extraConfig = ''
-      # https://github.com/nix-community/home-manager/issues/7771
-      # shortcut = "a";
-      unbind C-b
-      set -g prefix C-a
-      bind -N "Send the prefix key through to the application" C-a send-prefix
-
       set -ogq @snig_session "#{session_name}"
 
       set -g renumber-windows on
       set -g detach-on-destroy off
-      set -g terminal-overrides ",*:RGB"
+
+      set -as terminal-overrides ",alacritty*:Tc"
+      set -as terminal-features ",alacritty*:usstyle"
 
       set -g status-style 'bg=default'
       set -g status-position top


### PR DESCRIPTION
- Home-manager introduced fix for shortcut passthrough
- Make use of Alacritty underline codes
- Remove RGB line as it seems to have no effect